### PR TITLE
Refactor/clean code

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,11 +1,19 @@
 # History
 
+## Unreleased
+
+-   Clean `registerSocketForUser` method
+    -   Add `extractUserId` method (private): Parses and validates `userId` from incoming data, throwing an error if `userId` is missing.
+    -   Add `handleExistingConnection` method (private): Checks and disconnects existing sockets for a user, ensuring only one active connection.
+    -   Add `saveUserSocketsToRedis` method (private): Manages Redis persistence of active user sockets, updating data after each connection change.
+
 ## v1.0.0 - Initial Release
-- **Initial Features**:
-  - **Single Active Connection per User**: Maintains one active WebSocket connection per user, disconnecting prior connections.
-  - **Redis-Powered Persistence**: Stores and retrieves active user sockets via Redis, supporting distributed WebSocket applications.
-  - **User Socket Management**: 
-    - Register and deregister sockets for users.
-    - Retrieve a user’s active socket.
-  - **Event Emission**: Emit events directly to a specified user socket.
-  - **Namespace Support**: Optionally set up namespaces for organized socket management.
+
+-   **Initial Features**:
+    -   **Single Active Connection per User**: Maintains one active WebSocket connection per user, disconnecting prior connections.
+    -   **Redis-Powered Persistence**: Stores and retrieves active user sockets via Redis, supporting distributed WebSocket applications.
+    -   **User Socket Management**:
+        -   Register and deregister sockets for users.
+        -   Retrieve a user’s active socket.
+    -   **Event Emission**: Emit events directly to a specified user socket.
+    -   **Namespace Support**: Optionally set up namespaces for organized socket management.

--- a/test/SockManage.test.ts
+++ b/test/SockManage.test.ts
@@ -1,15 +1,15 @@
-import { createClient } from "redis";
-import { Namespace, Socket, Server as SocketIOServer } from "socket.io";
-import { SockManage } from "../src/SockManage";
+import { createClient } from 'redis';
+import { Namespace, Socket, Server as SocketIOServer } from 'socket.io';
+import { SockManage } from '../src/SockManage';
 
-jest.mock("redis", () => ({
+jest.mock('redis', () => ({
     createClient: jest.fn().mockReturnValue({
         get: jest.fn(),
         set: jest.fn(),
     }),
 }));
 
-jest.mock("socket.io", () => ({
+jest.mock('socket.io', () => ({
     Server: jest.fn().mockReturnValue({
         of: jest.fn().mockReturnValue({
             sockets: new Map(),
@@ -20,7 +20,7 @@ jest.mock("socket.io", () => ({
     }),
 }));
 
-describe("SockManage", () => {
+describe('SockManage', () => {
     let redisClient: any;
     let io: SocketIOServer;
     let namespace: Namespace;
@@ -29,14 +29,14 @@ describe("SockManage", () => {
 
     beforeAll(() => {
         consoleErrorMock = jest
-            .spyOn(console, "error")
+            .spyOn(console, 'error')
             .mockImplementation(() => {});
     });
 
     beforeEach(() => {
         redisClient = createClient();
         io = new SocketIOServer();
-        namespace = io.of("/");
+        namespace = io.of('/');
         socketManager = new SockManage({ redis: redisClient });
     });
 
@@ -44,40 +44,40 @@ describe("SockManage", () => {
         consoleErrorMock.mockRestore();
     });
 
-    describe("setup", () => {
-        it("should set up the io and namespace", () => {
-            socketManager.setup({ io, namespace: "/test" });
+    describe('setup', () => {
+        it('should set up the io and namespace', () => {
+            socketManager.setup({ io, namespace: '/test' });
 
-            expect(socketManager["io"]).toBe(io);
-            expect(socketManager["namespace"]).toBe(namespace);
+            expect(socketManager['io']).toBe(io);
+            expect(socketManager['namespace']).toBe(namespace);
         });
     });
 
-    describe("initializeUserSockets", () => {
-        it("should initialize user sockets from Redis", async () => {
-            const userSockets = JSON.stringify([["user1", "socket1"]]);
+    describe('initializeUserSockets', () => {
+        it('should initialize user sockets from Redis', async () => {
+            const userSockets = JSON.stringify([['user1', 'socket1']]);
 
             redisClient.get.mockResolvedValue(userSockets);
 
             await socketManager.initializeUserSockets();
 
-            expect(socketManager["userSockets"].get("user1")).toBe("socket1");
+            expect(socketManager['userSockets'].get('user1')).toBe('socket1');
         });
     });
 
-    describe("getUserSockets", () => {
-        it("should return user sockets from Redis", async () => {
-            const userSockets = JSON.stringify([["user1", "socket1"]]);
+    describe('getUserSockets', () => {
+        it('should return user sockets from Redis', async () => {
+            const userSockets = JSON.stringify([['user1', 'socket1']]);
 
             redisClient.get.mockResolvedValue(userSockets);
 
             const result = await socketManager.getUserSockets();
 
-            expect(result?.get("user1")).toBe("socket1");
+            expect(result?.get('user1')).toBe('socket1');
         });
 
-        it("should return null if Redis data is invalid", async () => {
-            redisClient.get.mockResolvedValue("invalid data");
+        it('should return null if Redis data is invalid', async () => {
+            redisClient.get.mockResolvedValue('invalid data');
 
             const result = await socketManager.getUserSockets();
 
@@ -85,84 +85,93 @@ describe("SockManage", () => {
         });
     });
 
-    describe("getUserSocket", () => {
-        it("should return the socket ID for a given user", async () => {
-            const userSockets = JSON.stringify([["user1", "socket1"]]);
+    describe('getUserSocket', () => {
+        it('should return the socket ID for a given user', async () => {
+            const userSockets = JSON.stringify([['user1', 'socket1']]);
 
             redisClient.get.mockResolvedValue(userSockets);
 
-            const result = await socketManager.getUserSocket("user1");
+            const result = await socketManager.getUserSocket('user1');
 
-            expect(result).toBe("socket1");
+            expect(result).toBe('socket1');
         });
 
-        it("should return null if the user does not exist", async () => {
+        it('should return null if the user does not exist', async () => {
             redisClient.get.mockResolvedValue(null);
 
-            const result = await socketManager.getUserSocket("user1");
+            const result = await socketManager.getUserSocket('user1');
 
             expect(result).toBeNull();
         });
     });
 
-    describe("registerSocketForUser", () => {
-        it("should register a socket for a user", async () => {
-            const socket = { id: "socket1" } as Socket;
-            const data = JSON.stringify({ userId: "user1" });
+    describe('registerSocketForUser', () => {
+        it('should throw an error if userId is not found in data', async () => {
+            const socket = {} as Socket;
+            const data = JSON.stringify({});
+
+            await expect(
+                socketManager.registerSocketForUser(socket, data)
+            ).rejects.toThrow('userId not found in data, it is required!');
+        });
+
+        it('should register a socket for a user', async () => {
+            const socket = { id: 'socket1' } as Socket;
+            const data = JSON.stringify({ userId: 'user1' });
 
             await socketManager.registerSocketForUser(socket, data);
 
-            expect(socketManager["userSockets"].get("user1")).toBe("socket1");
+            expect(socketManager['userSockets'].get('user1')).toBe('socket1');
             expect(redisClient.set).toHaveBeenCalledWith(
-                "userSockets",
-                JSON.stringify([["user1", "socket1"]])
+                'userSockets',
+                JSON.stringify([['user1', 'socket1']])
             );
         });
 
-        it("should disconnect existing socket if a new one is registered", async () => {
-            socketManager.setup({ io, namespace: "/test" });
+        it('should disconnect existing socket if a new one is registered', async () => {
+            socketManager.setup({ io, namespace: '/test' });
 
             const existingSocket = {
-                id: "socket1",
+                id: 'socket1',
                 disconnect: jest.fn(),
             } as unknown as Socket;
 
-            namespace.sockets.set("socket1", existingSocket);
+            namespace.sockets.set('socket1', existingSocket);
 
-            const socket = { id: "socket2" } as Socket;
-            const data = JSON.stringify({ userId: "user1" });
+            const socket = { id: 'socket2' } as Socket;
+            const data = JSON.stringify({ userId: 'user1' });
 
-            socketManager["userSockets"].set("user1", "socket1");
+            socketManager['userSockets'].set('user1', 'socket1');
 
             await socketManager.registerSocketForUser(socket, data);
 
             expect(existingSocket.disconnect).toHaveBeenCalledWith(true);
-            expect(socketManager["userSockets"].get("user1")).toBe("socket2");
+            expect(socketManager['userSockets'].get('user1')).toBe('socket2');
         });
     });
 
-    describe("deRegisterSocketForUser", () => {
-        it("should deregister a socket for a user", () => {
+    describe('deRegisterSocketForUser', () => {
+        it('should deregister a socket for a user', () => {
             const socket = {
-                id: "socket1",
-                data: { userId: "user1" },
+                id: 'socket1',
+                data: { userId: 'user1' },
             } as unknown as Socket;
 
-            socketManager["userSockets"].set("user1", "socket1");
+            socketManager['userSockets'].set('user1', 'socket1');
 
             socketManager.deRegisterSocketForUser(socket);
 
-            expect(socketManager["userSockets"].has("user1")).toBe(false);
+            expect(socketManager['userSockets'].has('user1')).toBe(false);
         });
     });
 
-    describe("informSocket", () => {
-        it("should inform a socket with an event and data", () => {
-            const socketId = "socket1";
-            const _event = "testEvent";
-            const data = { message: "test" };
+    describe('informSocket', () => {
+        it('should inform a socket with an event and data', () => {
+            const socketId = 'socket1';
+            const _event = 'testEvent';
+            const data = { message: 'test' };
 
-            socketManager.setup({ io, namespace: "/test" });
+            socketManager.setup({ io, namespace: '/test' });
 
             socketManager.informSocket({
                 socketId,


### PR DESCRIPTION
-   Clean `registerSocketForUser` method
    -   Add `extractUserId` method (private): Parses and validates `userId` from incoming data, throwing an error if `userId` is missing.
    -   Add `handleExistingConnection` method (private): Checks and disconnects existing sockets for a user, ensuring only one active connection.
    -   Add `saveUserSocketsToRedis` method (private): Manages Redis persistence of active user sockets, updating data after each connection change.

### Notes

- Fixes #3 