### PR TITLE
refactor: `getSocket` and `getSockets` 

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 # History
 
+## Unreleased
+
+-   Refactor `getSockets` to return `this.userSockets` directly instead of using Redis.
+-   Refactor `getSocket` to return `this.userSockets.get(userId)` directly instead of using Redis.
+
 ## v1.0.1
 
 -   Clean `registerSocketForUser` method

--- a/src/SockManage.ts
+++ b/src/SockManage.ts
@@ -1,6 +1,6 @@
-import { RedisClientType } from 'redis';
-import { Namespace, Socket, Server as SocketIOServer } from 'socket.io';
-import { deprecate } from 'util';
+import { RedisClientType } from "redis";
+import { Namespace, Socket, Server as SocketIOServer } from "socket.io";
+import { deprecate } from "util";
 
 interface SocketManagerOptions {
     redis: RedisClientType;
@@ -87,7 +87,7 @@ export class SockManage {
      */
     setup({ io, namespace }: SetupOptions): void {
         this.io = io;
-        this.namespace = namespace ? this.io.of(namespace) : this.io.of('/');
+        this.namespace = namespace ? this.io.of(namespace) : this.io.of("/");
     }
 
     /**
@@ -97,7 +97,7 @@ export class SockManage {
      * @returns {Promise<void>} A promise that resolves when the user sockets have been initialized.
      */
     async initialize(): Promise<void> {
-        let userSockets = await this.redis.get('userSockets');
+        let userSockets = await this.redis.get("userSockets");
 
         if (userSockets) {
             this.userSockets = new Map(JSON.parse(userSockets));
@@ -109,39 +109,16 @@ export class SockManage {
      */
     initializeUserSockets = deprecate(
         this.initialize,
-        'initializeUserSockets() is deprecated. Use initialize() instead.'
+        "initializeUserSockets() is deprecated. Use initialize() instead."
     );
 
     /**
-     * Retrieves the user sockets from Redis.
+     * Retrieves the map of user sockets.
      *
-     * @returns {Promise<Map<string, string> | null>} A promise that resolves to a Map of user sockets if available, or null if not found or an error occurs.
-     *
-     * @throws Will log an error message if there is an issue retrieving or parsing the user sockets from Redis.
+     * @returns {Map<string, string>} A map where the keys are user identifiers and the values are socket identifiers.
      */
-    async getSockets(): Promise<Map<string, string> | null> {
-        try {
-            let userSockets = await this.redis.get('userSockets');
-
-            if (userSockets) {
-                try {
-                    return new Map(JSON.parse(userSockets));
-                } catch (error) {
-                    console.error(
-                        'Failed to parse userSockets from Redis:',
-                        error
-                    );
-
-                    return null;
-                }
-            }
-
-            return null;
-        } catch (error) {
-            console.error('Error retrieving userSockets from Redis:', error);
-
-            return null;
-        }
+    getSockets(): Map<string, string> {
+        return this.userSockets;
     }
 
     /**
@@ -149,19 +126,17 @@ export class SockManage {
      */
     getUserSockets = deprecate(
         this.getSockets,
-        'getUserSockets() is deprecated. Use getSockets() instead.'
+        "getUserSockets() is deprecated. Use getSockets() instead."
     );
 
     /**
-     * Retrieves the socket ID associated with a given user ID.
+     * Retrieves the socket ID associated with a user.
      *
      * @param userId - The unique identifier of the user.
-     * @returns A promise that resolves to the socket ID as a string if found, or null if not found.
+     * @returns The socket ID if found, otherwise `null`.
      */
-    async getSocket(userId: string): Promise<string | null> {
-        const userSockets = await this.getSockets();
-
-        return userSockets ? userSockets.get(userId) || null : null;
+    getSocket(userId: string): string | null {
+        return this.userSockets.get(userId) || null;
     }
 
     /**
@@ -169,7 +144,7 @@ export class SockManage {
      */
     getUserSocket = deprecate(
         this.getSocket,
-        'getUserSocket() is deprecated. Use getSocket() instead.'
+        "getUserSocket() is deprecated. Use getSocket() instead."
     );
 
     /**
@@ -184,7 +159,7 @@ export class SockManage {
         const userId = this.extractUserId(data);
 
         if (!userId) {
-            throw new Error('userId not found in data, it is required!');
+            throw new Error("userId not found in data, it is required!");
         }
 
         await this.handleExistingConnection(userId, socket);
@@ -198,7 +173,7 @@ export class SockManage {
      */
     registerSocketForUser = deprecate(
         this.register,
-        'registerSocketForUser() is deprecated. Use register() instead.'
+        "registerSocketForUser() is deprecated. Use register() instead."
     );
 
     /**
@@ -214,7 +189,7 @@ export class SockManage {
 
             return parsedData.userId || null;
         } catch (error) {
-            console.error('Failed to parse user data:', error);
+            console.error("Failed to parse user data:", error);
             return null;
         }
     }
@@ -252,11 +227,11 @@ export class SockManage {
     private async saveUserSocketsToRedis(): Promise<void> {
         try {
             await this.redis.set(
-                'userSockets',
+                "userSockets",
                 JSON.stringify(Array.from(this.userSockets.entries()))
             );
         } catch (error) {
-            console.error('Failed to persist user sockets in Redis:', error);
+            console.error("Failed to persist user sockets in Redis:", error);
         }
     }
 
@@ -283,7 +258,7 @@ export class SockManage {
      */
     deRegisterSocketForUser = deprecate(
         this.deRegister,
-        'deRegisterSocketForUser() is deprecated. Use deRegister() instead.'
+        "deRegisterSocketForUser() is deprecated. Use deRegister() instead."
     );
 
     /**
@@ -297,7 +272,7 @@ export class SockManage {
      * @returns {void}
      */
     inform({
-        namespace = '/',
+        namespace = "/",
         socketId,
         _event,
         data,
@@ -310,6 +285,6 @@ export class SockManage {
      */
     informSocket = deprecate(
         this.inform,
-        'informSocket() is deprecated. Use inform() instead.'
+        "informSocket() is deprecated. Use inform() instead."
     );
 }

--- a/test/SockManage.test.ts
+++ b/test/SockManage.test.ts
@@ -1,15 +1,15 @@
-import { createClient } from 'redis';
-import { Namespace, Socket, Server as SocketIOServer } from 'socket.io';
-import { SockManage } from '../src/SockManage';
+import { createClient } from "redis";
+import { Namespace, Socket, Server as SocketIOServer } from "socket.io";
+import { SockManage } from "../src/SockManage";
 
-jest.mock('redis', () => ({
+jest.mock("redis", () => ({
     createClient: jest.fn().mockReturnValue({
         get: jest.fn(),
         set: jest.fn(),
     }),
 }));
 
-jest.mock('socket.io', () => ({
+jest.mock("socket.io", () => ({
     Server: jest.fn().mockReturnValue({
         of: jest.fn().mockReturnValue({
             sockets: new Map(),
@@ -20,7 +20,7 @@ jest.mock('socket.io', () => ({
     }),
 }));
 
-describe('SockManage', () => {
+describe("SockManage", () => {
     let redisClient: any;
     let io: SocketIOServer;
     let namespace: Namespace;
@@ -29,14 +29,14 @@ describe('SockManage', () => {
 
     beforeAll(() => {
         consoleErrorMock = jest
-            .spyOn(console, 'error')
+            .spyOn(console, "error")
             .mockImplementation(() => {});
     });
 
     beforeEach(() => {
         redisClient = createClient();
         io = new SocketIOServer();
-        namespace = io.of('/');
+        namespace = io.of("/");
         socketManager = new SockManage({ redis: redisClient });
     });
 
@@ -44,134 +44,140 @@ describe('SockManage', () => {
         consoleErrorMock.mockRestore();
     });
 
-    describe('setup', () => {
-        it('should set up the io and namespace', () => {
-            socketManager.setup({ io, namespace: '/test' });
+    describe("setup", () => {
+        it("should set up the io and namespace", () => {
+            socketManager.setup({ io, namespace: "/test" });
 
-            expect(socketManager['io']).toBe(io);
-            expect(socketManager['namespace']).toBe(namespace);
+            expect(socketManager["io"]).toBe(io);
+            expect(socketManager["namespace"]).toBe(namespace);
         });
     });
 
-    describe('initialize', () => {
-        it('should initialize user sockets from Redis', async () => {
-            const userSockets = JSON.stringify([['user1', 'socket1']]);
+    describe("initialize", () => {
+        it("should initialize user sockets from Redis", async () => {
+            const userSockets = JSON.stringify([["user1", "socket1"]]);
 
             redisClient.get.mockResolvedValue(userSockets);
 
             await socketManager.initialize();
 
-            expect(socketManager['userSockets'].get('user1')).toBe('socket1');
+            expect(socketManager["userSockets"].get("user1")).toBe("socket1");
         });
     });
 
-    describe('getSockets', () => {
-        it('should return user sockets from Redis', async () => {
-            const userSockets = JSON.stringify([['user1', 'socket1']]);
+    describe("getSockets", () => {
+        it("should return user sockets from Redis", async () => {
+            await socketManager.initialize();
+
+            const userSockets = JSON.stringify([["user1", "socket1"]]);
 
             redisClient.get.mockResolvedValue(userSockets);
 
-            const result = await socketManager.getSockets();
+            const result = socketManager.getSockets();
 
-            expect(result?.get('user1')).toBe('socket1');
+            expect(result?.get("user1")).toBe("socket1");
         });
 
-        it('should return null if Redis data is invalid', async () => {
-            redisClient.get.mockResolvedValue('invalid data');
+        it("should return empty map if Redis data is invalid", async () => {
+            await socketManager.initialize();
 
-            const result = await socketManager.getSockets();
+            redisClient.get.mockResolvedValue("invalid data");
 
-            expect(result).toBeNull();
+            const result = socketManager.getSockets();
+
+            expect(result).toBeInstanceOf(Map);
         });
     });
 
-    describe('getSocket', () => {
-        it('should return the socket ID for a given user', async () => {
-            const userSockets = JSON.stringify([['user1', 'socket1']]);
+    describe("getSocket", () => {
+        it("should return the socket ID for a given user", async () => {
+            const userSockets = JSON.stringify([["user1", "socket1"]]);
 
             redisClient.get.mockResolvedValue(userSockets);
 
-            const result = await socketManager.getSocket('user1');
+            await socketManager.initialize();
 
-            expect(result).toBe('socket1');
+            const result = socketManager.getSocket("user1");
+
+            expect(result).toBe("socket1");
         });
 
-        it('should return null if the user does not exist', async () => {
+        it("should return null if the user does not exist", async () => {
             redisClient.get.mockResolvedValue(null);
 
-            const result = await socketManager.getSocket('user1');
+            const result = await socketManager.getSocket("user1");
 
             expect(result).toBeNull();
         });
     });
 
-    describe('register', () => {
-        it('should throw an error if userId is not found in data', async () => {
+    describe("register", () => {
+        it("should throw an error if userId is not found in data", async () => {
             const socket = {} as Socket;
             const data = JSON.stringify({});
 
             await expect(socketManager.register(socket, data)).rejects.toThrow(
-                'userId not found in data, it is required!'
+                "userId not found in data, it is required!"
             );
         });
 
-        it('should register a socket for a user', async () => {
-            const socket = { id: 'socket1' } as Socket;
-            const data = JSON.stringify({ userId: 'user1' });
+        it("should register a socket for a user", async () => {
+            const socket = { id: "socket1" } as Socket;
+            const data = JSON.stringify({ userId: "user1" });
 
             await socketManager.register(socket, data);
 
-            expect(socketManager['userSockets'].get('user1')).toBe('socket1');
+            expect(socketManager["userSockets"].get("user1")).toBe("socket1");
             expect(redisClient.set).toHaveBeenCalledWith(
-                'userSockets',
-                JSON.stringify([['user1', 'socket1']])
+                "userSockets",
+                JSON.stringify([["user1", "socket1"]])
             );
         });
 
-        it('should disconnect existing socket if a new one is registered', async () => {
-            socketManager.setup({ io, namespace: '/test' });
+        it("should disconnect existing socket if a new one is registered", async () => {
+            socketManager.setup({ io, namespace: "/test" });
 
             const existingSocket = {
-                id: 'socket1',
+                id: "socket1",
                 disconnect: jest.fn(),
             } as unknown as Socket;
 
-            namespace.sockets.set('socket1', existingSocket);
+            namespace.sockets.set("socket1", existingSocket);
 
-            const socket = { id: 'socket2' } as Socket;
-            const data = JSON.stringify({ userId: 'user1' });
+            const socket = { id: "socket2" } as Socket;
+            const data = JSON.stringify({ userId: "user1" });
 
-            socketManager['userSockets'].set('user1', 'socket1');
+            socketManager["userSockets"].set("user1", "socket1");
 
             await socketManager.register(socket, data);
 
             expect(existingSocket.disconnect).toHaveBeenCalledWith(true);
-            expect(socketManager['userSockets'].get('user1')).toBe('socket2');
+            expect(socketManager["userSockets"].get("user1")).toBe("socket2");
         });
     });
 
-    describe('deRegister', () => {
-        it('should deregister a socket for a user', () => {
+    describe("deRegister", () => {
+        it("should deregister a socket for a user", () => {
             const socket = {
-                id: 'socket1',
-                data: { userId: 'user1' },
+                id: "socket1",
+                data: { userId: "user1" },
             } as unknown as Socket;
 
-            socketManager['userSockets'].set('user1', 'socket1');
+            socketManager["userSockets"].set("user1", "socket1");
 
             socketManager.deRegister(socket);
 
-            expect(socketManager['userSockets'].has('user1')).toBe(false);
+            expect(socketManager["userSockets"].has("user1")).toBe(false);
         });
     });
 
-    describe('inform', () => {
-        it('should inform a socket with an event and data', () => {
-            const socketId = 'socket1';
-            const _event = 'testEvent';
-            const data = { message: 'test' };
+    describe("inform", () => {
+        it("should inform a socket with an event and data", () => {
+            const socketId = "socket1";
+            const _event = "testEvent";
+            const data = { message: "test" };
 
-            socketManager.setup({ io, namespace: '/test' });
+            socketManager.setup({ io, namespace: "/test" });
 
             socketManager.inform({
                 socketId,


### PR DESCRIPTION
They now work directly with this.userSockets as redis is initialized at the beginning